### PR TITLE
fix: error msg when passing nonexisting file to photon create command

### DIFF
--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -875,9 +875,18 @@ class Photon(BasePhoton):
                         model_str = f"{model_str}:{cls_name}"
             elif "." in path:
                 module_str, _, cls_name = path.rpartition(".")
-                module = importlib.import_module(module_str)
+                try:
+                    module = importlib.import_module(module_str)
+                except ModuleNotFoundError:
+                    raise ValueError(
+                        f"'{path}' is neither an existing file nor an importable python"
+                        " variable"
+                    )
             else:
-                raise ValueError(f"Can not find file or module: {path}")
+                raise ValueError(
+                    f"'{path}' is neither an existing file nor an importable python"
+                    " variable"
+                )
 
             cloudpickle.register_pickle_by_value(module)
             ph_cls = getattr(module, cls_name)

--- a/leptonai/photon/tests/test_photon_cli.py
+++ b/leptonai/photon/tests/test_photon_cli.py
@@ -324,6 +324,7 @@ class CustomPhoton(Photon):
             ("py:leptonai.photon.prebuilt.Echo", True),
             # invalid
             (random_name(), False),
+            ("nonexisting.py", False, "file"),
             # hf
             (transformers_model, True),
             # hf without "hf:"
@@ -332,12 +333,20 @@ class CustomPhoton(Photon):
             ("leptonai.photon.hf.hf.HuggingfaceTextGenerationPhoton", False),
         ]
 
-        for model, valid in test_cases:
+        for test_case in test_cases:
+            if len(test_case) == 2:
+                model, valid = test_case
+                msg = None
+            else:
+                model, valid, msg = test_case
+
             try:
                 proc = None
                 proc, _ = photon_run_local_server(name=random_name(), model=model)
-            except Exception:
+            except Exception as e:
                 self.assertFalse(valid, f"Model {model} should be invalid")
+                if msg is not None:
+                    self.assertIn(msg, str(e))
             else:
                 self.assertTrue(valid, f"Model {model} should be valid")
             finally:


### PR DESCRIPTION
Closes: #33

```
$ lep photon create -n test -m nonexistent.py
Failed to create photon: 'nonexistent.py' is neither an existing file nor an importable python variable
```

