### PR TITLE
feat(cli): print more helpful client note

### DIFF
--- a/leptonai/photon/photon.py
+++ b/leptonai/photon/photon.py
@@ -483,26 +483,48 @@ class Photon(BasePhoton):
         logger.propagate = False
         # Send the welcome message, especially to make sure that users will know
         # whicl URL to visit in order to not get a "not found" error.
-        logger.info("If you are using standard photon, a few urls that may be helpful:")
         logger.info(
-            "\t- "
-            + click.style(f"http://{host}:{port}/docs", fg="green", bold=True)
-            + " OpenAPI documentation"
-        )
-        logger.info(
-            "\t- "
-            + click.style(f"http://{host}:{port}/redoc", fg="green", bold=True)
-            + " Redoc documentation"
-        )
-        logger.info(
-            "\t- "
-            + click.style(f"http://{host}:{port}/openapi.json", fg="green", bold=True)
-            + " Raw OpenAPI schema"
-        )
-        logger.info(
-            "\t- "
-            + click.style(f"http://{host}:{port}/metrics", fg="green", bold=True)
-            + " Prometheus metrics"
+            "\n".join(
+                [
+                    (
+                        "\nIf you are using standard photon, a few urls that may be"
+                        " helpful:"
+                    ),
+                    "\t- "
+                    + click.style(f"http://{host}:{port}/docs", fg="green", bold=True)
+                    + " OpenAPI documentation",
+                    "\t- "
+                    + click.style(f"http://{host}:{port}/redoc", fg="green", bold=True)
+                    + " Redoc documentation",
+                    "\t- "
+                    + click.style(
+                        f"http://{host}:{port}/openapi.json", fg="green", bold=True
+                    )
+                    + " Raw OpenAPI schema",
+                    "\t- "
+                    + click.style(
+                        f"http://{host}:{port}/metrics", fg="green", bold=True
+                    )
+                    + " Prometheus metrics",
+                    (
+                        "\nIf you are using python clients, here is an example code"
+                        " snippet:"
+                    ),
+                    "\tfrom leptonai.client import Client, local",
+                    f"\tclient = Client(local(port={port}))",
+                    "\tclient.healthz()  # checks the health of the photon",
+                    "\tclient.paths()  # lists all the paths of the photon",
+                    (
+                        "\tclient.method_name?  # If client has a method_name method,"
+                        " get the docstring"
+                    ),
+                    "\tclient.method_name(...)  # calls the method_name method",
+                    (
+                        "If you are using ipython, you can use tab completion by typing"
+                        " `client.` and then press tab.\n"
+                    ),
+                ]
+            )
         )
 
     def _uvicorn_run(self, host, port, log_level, log_config):


### PR DESCRIPTION
This allows the user to have some idea about how to use the service.

```
(lepton) ➜  sdk git:(yqcli) lep photon run -n gpt2 -m hf:gpt2 --local                    Rebuilding photon with --model hf:gpt2.
If you want to run without rebuilding, please remove the --model arg.
Photon gpt2 created.
Launching photon on port: 8080
2023-09-15 00:07:39.674 | INFO     | leptonai.photon.hf.hf:pipeline:167 - Creating pipeline for text-generation(model=gpt2, revision=11c5a3d5).
HuggingFace download might take a while, please be patient...
2023-09-15 00:07:55,349 - INFO:  
If you are using standard photon, a few urls that may be helpful:
        - http://0.0.0.0:8080/docs OpenAPI documentation
        - http://0.0.0.0:8080/redoc Redoc documentation
        - http://0.0.0.0:8080/openapi.json Raw OpenAPI schema
        - http://0.0.0.0:8080/metrics Prometheus metrics

If you are using python clients, here is an example code snippet:
        from leptonai.client import Client, local
        client = Client(local(port=8080))
        client.healthz()  # checks the health of the photon
        client.paths()  # lists all the paths of the photon
        client.method_name?  # If client has a method_name method, get the docstring
        client.method_name(...)  # calls the method_name method
If you are using ipython, you can use tab completion by typing `client.` and then press tab.

2023-09-15 00:07:55,356 - INFO:     Started server process [992611]
2023-09-15 00:07:55,356 - INFO:     Waiting for application startup.
2023-09-15 00:07:55,357 - INFO:     Application startup complete.
2023-09-15 00:07:55,357 - INFO:     Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)
```